### PR TITLE
v07 - fix missing permission control when editing authorized viewers on issues

### DIFF
--- a/lib/redmine_limited_visibility/models/issue_patch.rb
+++ b/lib/redmine_limited_visibility/models/issue_patch.rb
@@ -25,9 +25,8 @@ module RedmineLimitedVisibility
         belongs_to :assigned_function, class_name: "Function",
                 foreign_key: "assigned_to_function_id"
 
-        safe_attributes "authorized_viewers",
-                        "assigned_to_function_id",
-                        :if => lambda { |issue, user| user.admin? || user.allowed_to?(:change_issues_visibility, issue.project) }
+        safe_attributes "assigned_to_function_id"
+        safe_attributes "authorized_viewers", :if => lambda { |issue, user| user.admin? || user.allowed_to?(:change_issues_visibility, issue.project) }
 
         def involved_users(project)
           if project.module_enabled?("limited_visibility")

--- a/lib/redmine_limited_visibility/models/issue_patch.rb
+++ b/lib/redmine_limited_visibility/models/issue_patch.rb
@@ -25,8 +25,9 @@ module RedmineLimitedVisibility
         belongs_to :assigned_function, class_name: "Function",
                 foreign_key: "assigned_to_function_id"
 
-
-        safe_attributes "authorized_viewers", "assigned_to_function_id"
+        safe_attributes "authorized_viewers",
+                        "assigned_to_function_id",
+                        :if => lambda { |issue, user| user.admin? || user.allowed_to?(:change_issues_visibility, issue.project) }
 
         def involved_users(project)
           if project.module_enabled?("limited_visibility")


### PR DESCRIPTION
## v07 
Ajout d'un contrôle de permission (:change_issues_visibility) lors la modification des groupes fonctionnels associés à un ticket