### PR TITLE
Ticket 172755

### DIFF
--- a/app/overrides/projects/copy.rb
+++ b/app/overrides/projects/copy.rb
@@ -3,4 +3,31 @@ Deface::Override.new  :virtual_path  => "projects/copy",
                       :insert_after  => ".block:contains('@source_project.wiki.nil?')",
                       :text          => <<EOS
 <label class="block"><%= check_box_tag 'only[]', 'functions', true, :id => nil %> <%= l(:label_functional_roles) %> (<%= @source_project.functions.count %>)</label>
+<script>
+  //disable it when member option not selected
+  $("input[value='members']").change(function() {
+    if ($(this).is(':checked')) {
+      $("input[value='functions_organizations_of_members']").prop( "disabled", false );
+    } else {
+      $("input[value='functions_organizations_of_members']").prop( "disabled", true );
+      $("input[value='functions_organizations_of_members']").prop( "checked", false );
+    }
+  });
+</script>
 EOS
+if Redmine::Plugin.installed?(:redmine_organizations)
+  Deface::Override.new  :virtual_path  => "projects/copy",
+                      :name          => "copy-projects-functions_organizations_of_members",
+                      :insert_after  => ".block:contains('@source_project.members.count')",
+                      :text          => <<EOS
+    <label class="block"><%= check_box_tag 'only[]', 'functions_organizations_of_members', true, :id => nil %> <%= l(:label_functions_organizations_of_members) %></label>
+EOS
+else
+  Deface::Override.new  :virtual_path  => "projects/copy",
+                    :name          => "copy-projects-functions_organizations_of_members",
+                    :insert_after  => ".block:contains('@source_project.members.count')",
+                    :text          => <<EOS
+  <label class="block"><%= check_box_tag 'only[]', 'functions_organizations_of_members', true, :id => nil %> <%= l(:label_functions_of_members) %></label>
+EOS
+end
+

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -52,3 +52,5 @@ en:
   label_copy_settings_from_another_project: "Copy settings from another project"
   label_select_project: "Select a project"
   label_no_other_project_configured_for_moment: "No other project is configured for the moment"
+  label_functions_organizations_of_members: "Functions and organizations of members"
+  label_functions_of_members: "Functions of members"

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -60,3 +60,5 @@ fr:
   label_copy_settings_from_another_project: "Copier les paramètres d'un autre projet"
   label_select_project: "Sélectionner un projet"
   label_no_other_project_configured_for_moment: "Aucun autre projet n'est configuré pour l'instant"
+  label_functions_organizations_of_members: "Fonctions et organisations des membres"
+  label_functions_of_members: "Fonctions des membres"

--- a/spec/controllers/projects_controller_spec.rb
+++ b/spec/controllers/projects_controller_spec.rb
@@ -100,11 +100,16 @@ describe ProjectsController, :type => :controller do
 
       expect(new_pro.members.count).to eq(source_project.members.count)
       expect(new_pro.project_functions.count).to eq(0)
-      expect(new_pro.organization_functions.count).to eq(0)
+      if Redmine::Plugin.installed?(:redmine_organizations)
+        expect(new_pro.organization_functions.count).to eq(0)
+      end
     end
 
     it "copy all functions and organizations of members" do
       @request.session[:user_id] = 1 # admin
+      pft = source_project.project_function_trackers.first
+      pft.visible = true
+      pft.save
       post :copy, :params => {
         :id => source_project.id,
         :project => {
@@ -116,8 +121,11 @@ describe ProjectsController, :type => :controller do
 
       new_pro = Project.last
 
+      expect(new_pro.project_function_trackers.first.visible).to eq(true)
       expect(new_pro.members.count).to eq(source_project.members.count)
       expect(new_pro.project_functions.count).to eq(source_project.project_functions.count)
+      expect(new_pro.project_functions.first.authorized_viewers).to eq('|1|2|')
+      expect(new_pro.project_functions.second.authorized_viewers).to eq('|2|')
       if Redmine::Plugin.installed?(:redmine_organizations)
         expect(new_pro.organization_functions.count).to eq(source_project.organization_functions.count)
       end

--- a/spec/models/project_patch_spec.rb
+++ b/spec/models/project_patch_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 describe Project do
 
   fixtures :users, :roles, :projects, :members, :member_roles, :issues, :issue_statuses,
-           :trackers, :enumerations, :custom_fields, :enabled_modules
+            :trackers, :enumerations, :custom_fields, :enabled_modules
 
   if Redmine::Plugin.installed?(:redmine_organizations)
     fixtures :organizations, :organization_functions, :organization_roles
@@ -23,7 +23,6 @@ describe Project do
 
       expect(@project.memberships.size).to eq @source_project.memberships.size
       expect(@project.organization_functions.size).to eq @source_project.organization_functions.size
-      expect(@project.organization_roles.size).to eq @source_project.organization_roles.size
 
       @project.memberships.each do |membership|
         assert membership


### PR DESCRIPTION
- Réutiliser la méthode copy_members de( redmine )
- Ajouter l'option Fonctions et organisations des membres(le désactiver lorsque l'option membre n'est pas sélectionnée)
- Ajouter la méthode copy_functions_organizations_of_members
- Ajouter la méthode copy_functions 
- Déplacer la copie de rôles d'organisation vers redmine_organizations